### PR TITLE
Update windows-server-2019.pkr.hcl

### DIFF
--- a/builds/windows/windows-server-2019/windows-server-2019.pkr.hcl
+++ b/builds/windows/windows-server-2019/windows-server-2019.pkr.hcl
@@ -559,7 +559,7 @@ source "vsphere-iso" "windows-server-datacenter-core" {
 
   // Removable Media Settings
   iso_paths   = ["[${var.common_iso_datastore}] ${var.common_iso_path}/${var.iso_file}", "[] /vmimages/tools-isoimages/${var.vm_guest_os_family}.iso"]
-  iso_checksu = "${var.common_iso_hash}:${var.iso_checksum}"
+  iso_checksum = "${var.common_iso_hash}:${var.iso_checksum}"
   cd_files = [
     "../../../scripts/${var.vm_guest_os_family}/",
     "../../../certificates/"


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/rainpole/packer-vsphere/blob/main/CONTRIBUTING.md) for making a pull request.

**Summary of Pull Request**

<!-- 
  Fixing a typo in windows-server-2019.pkr.hcl   checksum had been misspelled 
-->

**Type of Pull Request**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a something else.
      Please describe:

**Context of the Pull Request***

<!-- 
When building 2019 based servers the following error message is observed Starting the HashiCorp Packer build ...
Error: Unsupported argument

  on windows-server-2019.pkr.hcl line 562:
  (source code not available)

An argument named "iso_checksu" is not expected here. Did you mean
"iso_checksum"?. 
-->

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Tests have been been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!-- 
    Please check the one that applies to this pull request using "x". 
-->

- [ ] Yes, there are breaking changes.
- [X] No, there are no breaking changes.

<!-- 
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->